### PR TITLE
Update jquery reference

### DIFF
--- a/mail_editor/templates/admin/mail_editor/change_form.html
+++ b/mail_editor/templates/admin/mail_editor/change_form.html
@@ -4,7 +4,7 @@
 {% block extrahead %}
 {{ block.super }}
 <script>
-    $(document).ready(function() {
+    django.jQuery(document).ready(function() {
         $('#id_template_type').change(function(){
             $.get('{% url "mail_editor:template_variables" original.template_type %}', function(data, textStatus, jqXHR) {
                 $('.field-get_variable_help_text').innerHTML = data


### PR DESCRIPTION
Using the mail_editor with a newer django version (2.2) causes a undefined error in the template javascript. See the image below:

![image](https://user-images.githubusercontent.com/5655384/70610703-4e75a080-1c04-11ea-8177-a1455eadaf1b.png)
