### PR TITLE
Remove usage of Context since it's no longer supported in Django 1.11

### DIFF
--- a/mail_editor/mail_template.py
+++ b/mail_editor/mail_template.py
@@ -4,7 +4,7 @@ Defines helpers for validating e-mail templates
 from __future__ import absolute_import, unicode_literals
 
 from django.core.exceptions import ValidationError
-from django.template import Context, Template, TemplateSyntaxError  # TODO: should be able to specify engine
+from django.template import Template, TemplateSyntaxError  # TODO: should be able to specify engine
 from django.template.base import VariableNode
 from django.utils.translation import ugettext_lazy as _
 
@@ -46,7 +46,7 @@ class MailTemplateValidator(object):
             else:
                 _error = exc
                 source = None
-            error = Template(error_tpl).render(Context({'error': _error, 'source': source}))
+            error = Template(error_tpl).render({'error': _error, 'source': source})
             raise ValidationError(error, code='syntax_error')
 
     def check_variables(self, template, field):

--- a/mail_editor/models.py
+++ b/mail_editor/models.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import copy
 import subprocess
 from tempfile import NamedTemporaryFile
 
@@ -8,7 +9,7 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import EmailMultiAlternatives
 from django.db import models
 from django.db.models import Q
-from django.template import Context, Template, loader
+from django.template import Template, loader
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.html import strip_tags
 from django.utils.safestring import mark_safe
@@ -28,10 +29,10 @@ class MailTemplateManager(models.Manager):
         """
         Returns the `MailTemplate` for the given type in the given language. If the language does not exist, it
         attempts to find and return the fallback (no language) instance.
-        
+
         :param template_type:
-        :param language: 
-        :return: 
+        :param language:
+        :return:
         """
         mail_template = self.filter(
             template_type=template_type
@@ -81,9 +82,9 @@ class MailTemplate(models.Model):
         tpl_subject = Template(self.subject)
         tpl_body = Template(self.body)
 
-        ctx = Context(base_context)
+        ctx = copy.deepcopy(base_context)
         ctx.update(context)
-        subj_ctx = Context(base_context)
+        subj_ctx = copy.deepcopy(base_context)
         subj_ctx.update(subj_context)
 
         partial_body = tpl_body.render(ctx)
@@ -94,7 +95,7 @@ class MailTemplate(models.Model):
         except Exception as e:
             domain = ''
 
-        body_context = Context(base_context)
+        body_context = copy.deepcopy(base_context)
         body_context.update({'domain': domain, 'content': partial_body})
         body = template.render(body_context, None)
 


### PR DESCRIPTION
Reference https://docs.djangoproject.com/en/1.11/releases/1.11/

The relevant part of the documents say 


_django.template.backends.django.Template.render() prohibits non-dict context_

_For compatibility with multiple template engines, django.template.backends.django.Template.render() (returned from high-level template loader APIs such as loader.get_template()) must receive a dictionary of context rather than Context or RequestContext. If you were passing either of the two classes, pass a dictionary instead – doing so is backwards-compatible with older versions of Django._


since we're using this for a project that is being upgraded to Django 1.11 I wanted to make this update.