### PR TITLE
Use Context when instantiating an object from Template

### DIFF
--- a/mail_editor/mail_template.py
+++ b/mail_editor/mail_template.py
@@ -4,7 +4,7 @@ Defines helpers for validating e-mail templates
 from __future__ import absolute_import, unicode_literals
 
 from django.core.exceptions import ValidationError
-from django.template import Template, TemplateSyntaxError  # TODO: should be able to specify engine
+from django.template import Context, Template, TemplateSyntaxError  # TODO: should be able to specify engine
 from django.template.base import VariableNode
 from django.utils.translation import ugettext_lazy as _
 
@@ -46,7 +46,7 @@ class MailTemplateValidator(object):
             else:
                 _error = exc
                 source = None
-            error = Template(error_tpl).render({'error': _error, 'source': source})
+            error = Template(error_tpl).render(Context({'error': _error, 'source': source}))
             raise ValidationError(error, code='syntax_error')
 
     def check_variables(self, template, field):

--- a/mail_editor/models.py
+++ b/mail_editor/models.py
@@ -9,7 +9,7 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import EmailMultiAlternatives
 from django.db import models
 from django.db.models import Q
-from django.template import Template, loader
+from django.template import Context, Template, loader
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.html import strip_tags
 from django.utils.safestring import mark_safe
@@ -82,9 +82,9 @@ class MailTemplate(models.Model):
         tpl_subject = Template(self.subject)
         tpl_body = Template(self.body)
 
-        ctx = copy.deepcopy(base_context)
+        ctx = Context(base_context)
         ctx.update(context)
-        subj_ctx = copy.deepcopy(base_context)
+        subj_ctx = Context(base_context)
         subj_ctx.update(subj_context)
 
         partial_body = tpl_body.render(ctx)


### PR DESCRIPTION
So Django is a bit weird with its usage of `Context`.  

When creating a `Template` instance and then calling `render` you **do** need to provide a `Context` instance.  https://github.com/django/django/blob/1.11.28/django/template/base.py#L201

When getting a template using `get_template` and then calling `render` you **do** **not** pass a `Context` but just a `dict`. https://docs.djangoproject.com/en/1.11/ref/templates/upgrading/#django-template-loader
 
Since we are doing both we need to use `Context` in some places and not in others.  Therefore  https://github.com/maykinmedia/mail-editor/pull/16 changed too much so this reverts the necessary code. 