### PR TITLE
[OIP-3341] Use dynamic template variables instead of static examples

### DIFF
--- a/mail_editor/models.py
+++ b/mail_editor/models.py
@@ -120,7 +120,7 @@ class MailTemplate(models.Model):
         def _get_context(section):
             context = {}
             for var in section:
-                value = var.example or base_context.get(var.name, "")
+                value = base_context.get(var.name, "")
                 if not value:
                     value = "--{}--".format(var.name)
                 context[var.name] = value

--- a/tests/test_template_rendering.py
+++ b/tests/test_template_rendering.py
@@ -111,5 +111,4 @@ class TemplateRenderTestCase(TestCase):
 
         # rendered placeholder
         self.assertEqual(subject, "Important message for --id--")
-        # rendered example
-        self.assertIn("Test mail sent from testcase with 321", body)
+        self.assertIn("Test mail sent from testcase with --id--", body)


### PR DESCRIPTION
The function for updating the template context with the values of user-definable variables defaulted to statically defined example values, hence user-defined values were ignored.

Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/issue/3341