### PR TITLE
Move configuration for bumpversion to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,10 +84,9 @@ DJANGO_SETTINGS_MODULE = "testapp.settings"
 
 [tool.bumpversion]
 current_version = "0.3.7"
-files = [
-    {filename = "pyproject.toml"},
-    {filename = "README.rst"},
-]
+tag = true
+tag_name = "{new_version}"
+commit = true
 
 [tool.coverage.report]
 exclude_also = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bumpversion]
-current_version = 0.3.7
-
 [aliases]
 test = pytest
 


### PR DESCRIPTION
`setup.cfg` is deprecated for configuration of bumpversion. In addition, the configuration is updated to automatically create tags following the naming convention of the project (i.e. `0.3.8` not `v0.3.8`) as well as a separate "bump commit" with the relevant message ("bump version ABX -> XYZ").