### PR TITLE
Release/0.3.9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 MailEditor
 ==========
 
-:Version: 0.3.8
+:Version: 0.3.9
 
 |build-status| |code-quality| |black| |coverage|
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mail_editor"
-version = "0.3.8"
+version = "0.3.9"
 description = "A Django package for email template editing"
 authors = [
     {name = "Maykin Media", email = "support@maykinmedia.nl"}
@@ -82,7 +82,7 @@ testpaths = ["tests"]
 DJANGO_SETTINGS_MODULE = "testapp.settings"
 
 [tool.bumpversion]
-current_version = "0.3.8"
+current_version = "0.3.9"
 tag = true
 tag_name = "{new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,9 @@ current_version = "0.3.8"
 tag = true
 tag_name = "{new_version}"
 commit = true
+files = [
+    {filename = "README.rst"},
+]
 
 [tool.coverage.report]
 exclude_also = [


### PR DESCRIPTION
* Adds support for django 5.2 & python 3.13  in CI
  * Adds apps.py and default auto field config
  * Removes django-choices for requirements (was not used anyway)
* Switches to trusted patforms
* pins github actions and adds zizmor job
* Fixes badges in README